### PR TITLE
Add "skipLibCheck" to functions/tsconfig.json

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -5,6 +5,7 @@
     "noUnusedLocals": true,
     "outDir": "lib",
     "sourceMap": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "es2017"
   },


### PR DESCRIPTION
`"skipLibCheck": true` tells `tsc` to ignore node_modules which frequently have errors outside of developers' control